### PR TITLE
Allow looping with all actions

### DIFF
--- a/src/fsm.lua
+++ b/src/fsm.lua
@@ -9,6 +9,7 @@ M.SUCCEEDED     = 1
 M.NO_TRANSITION = 2
 M.PENDING       = 3
 M.CANCELLED     = 4
+M.NO_OP         = 5
 
 local function do_callback(handler, args)
   if handler then
@@ -64,7 +65,7 @@ local function build_transition(self, event, states)
       return M.CANCELLED
     end
 
-    if from == to then
+    if to == M.NO_OP then
       after_event(self, event, from, to, args)
       return M.NO_TRANSITION
     end
@@ -142,7 +143,7 @@ function M.create(cfg, target)
       table.insert(events_for_state[fr], event)
 
       -- Allow no-op transition if `to` is not specified.
-      states_for_event[event][fr] = to or fr
+      states_for_event[event][fr] = to or M.NO_OP
     end
   end
 


### PR DESCRIPTION
I don't know if you're still maintaining this, but I have found this addition useful. It does not change any existing defined behaviour, and it adds (what I think is) useful behaviour.

This change allows the user to define an event from and to the same state, while also ensuring all the callbacks get called. It preserves the existing behaviour of an event which has a `from` state but no `to` state, which returns a `NO_TRANSITION`.